### PR TITLE
Implements fixity block and manifest generation improvements

### DIFF
--- a/lib/moab_export.rb
+++ b/lib/moab_export.rb
@@ -110,6 +110,18 @@ module OcflTools
       return my_manifest
     end
 
+    def generate_ocfl_fixity
+      self.generate_ocfl_fixity_until_version(@current_version_id)
+    end
+
+    def generate_ocfl_fixity_until_version(version)
+      # @param [Integer] version number to generate manifest for. Manifest will include all prior versions.
+      # Fixity is basically a Manifest block inside a wrapping hash.
+      my_fixity = Hash.new
+      my_fixity["#{@digest}"] = generate_ocfl_manifest_until_version(version)
+      return my_fixity
+    end
+
     def generate_ocfl_manifest
       # @return [Hash] OCFL-compliant Manifest block; keys are digests, values are [Array] of files.
       self.generate_ocfl_manifest_until_version(@current_version_id)

--- a/lib/ocfl_inventory.rb
+++ b/lib/ocfl_inventory.rb
@@ -38,6 +38,11 @@ module OcflTools
       # output_hash['fixity'] = @fixity
       JSON.pretty_generate(output_hash)
     end
-  end
 
+    def crosscheck_digests
+      # requires values in @versions and @manifest.
+      # verifies that every digest in @versions can be found in @manifest.
+      
+    end
+  end
 end

--- a/lib/ocfl_inventory.rb
+++ b/lib/ocfl_inventory.rb
@@ -36,13 +36,14 @@ module OcflTools
       output_hash['versions']         = @versions
       # optional
       # output_hash['fixity'] = @fixity
+      output_hash['fixity']           = @fixity unless @fixity.size == 0
       JSON.pretty_generate(output_hash)
     end
 
     def crosscheck_digests
       # requires values in @versions and @manifest.
       # verifies that every digest in @versions can be found in @manifest.
-      
+
     end
   end
 end

--- a/main.rb
+++ b/main.rb
@@ -33,9 +33,11 @@ export = OcflTools::MoabExport.new(moab)
 
 export.digest = 'sha256'
 
-ocfl = OcflTools::OcflInventory.new(druid, 3)
+ocfl = OcflTools::OcflInventory.new(export.digital_object_id, export.current_version_id)
 
 ocfl.versions = export.generate_ocfl_versions
 ocfl.manifest = export.generate_ocfl_manifest
 
 puts ocfl.serialize
+
+puts export.generate_ocfl_manifest_until_version(export.current_version_id)

--- a/main.rb
+++ b/main.rb
@@ -37,7 +37,9 @@ ocfl = OcflTools::OcflInventory.new(export.digital_object_id, export.current_ver
 
 ocfl.versions = export.generate_ocfl_versions
 ocfl.manifest = export.generate_ocfl_manifest
+export.digest = 'md5'
+ocfl.fixity = export.generate_ocfl_fixity
 
 puts ocfl.serialize
 
-puts export.generate_ocfl_manifest_until_version(export.current_version_id)
+#puts export.generate_ocfl_manifest_until_version(export.current_version_id)


### PR DESCRIPTION
Previous Manifest block was generated by trawling the filesystem, discovering files and computing checksums. That's fine! But potentially problematic for large objects that have already passed Moab audit. So, by default we assume that Moab is well-formed and the files have passed a recent fixity inspection (but re-generating checksums is still an option if you want it).

Also implements the fixity block (OCFL 3.5.4).  