### PR TITLE
Implement single line inventory.json creation

### DIFF
--- a/lib/druid_export.rb
+++ b/lib/druid_export.rb
@@ -1,0 +1,30 @@
+module OcflTools
+  class DruidExport
+    # A convenience class that wraps MoabExport and OcflInventory to produce an OCFL inventory file.
+
+    attr_accessor :export_directory
+
+    attr_reader :path, :moab, :export
+
+    def initialize(druid)
+      # @param [String] druid, a Stanford Druid object ID.
+
+      @path = Moab::StorageServices.object_path( druid )
+      @moab = Moab::StorageObject.new( druid , @path )
+      @export = OcflTools::MoabExport.new(@moab)
+      @export_directory = @moab.object_pathname # default value, can be changed.
+    end
+
+    def make_inventory
+      @export.digest = 'sha256'
+      ocfl = OcflTools::OcflInventory.new(@export.digital_object_id, @export.current_version_id)
+      ocfl.versions = @export.generate_ocfl_versions
+      ocfl.manifest = @export.generate_ocfl_manifest
+
+      @export.digest = 'md5'
+      ocfl.fixity = @export.generate_ocfl_fixity
+
+      ocfl.to_file(@export_directory)
+    end
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -40,8 +40,14 @@ ocfl.manifest = export.generate_ocfl_manifest
 export.digest = 'md5'
 ocfl.fixity = export.generate_ocfl_fixity
 
-puts ocfl.serialize
+#puts ocfl.serialize
 
-ocfl.to_file(path)
+#ocfl.to_file(path)
 
 #puts export.generate_ocfl_manifest_until_version(export.current_version_id)
+
+#druid_export = OcflTools::DruidExport.new(druid).make_inventory
+#druid_export.make_inventory
+
+# Given a [String] druid, make an OCFL inventory file in the object root.
+OcflTools::DruidExport.new(druid).make_inventory

--- a/main.rb
+++ b/main.rb
@@ -42,4 +42,6 @@ ocfl.fixity = export.generate_ocfl_fixity
 
 puts ocfl.serialize
 
+ocfl.to_file(path)
+
 #puts export.generate_ocfl_manifest_until_version(export.current_version_id)


### PR DESCRIPTION
Assuming your underlying code is set up correctly, 'OcflTools::DruidExport.new(druid).make_inventory' will create or replace an OCFL inventory file in the Moab object root with the most current version.